### PR TITLE
금융 수학

### DIFF
--- a/Financial-Analysis/Financial_math/approximation.py
+++ b/Financial-Analysis/Financial_math/approximation.py
@@ -1,0 +1,91 @@
+import numpy as np
+import scipy.interpolate as spi
+import matplotlib.pyplot as plt
+
+#! 근사화의 핵심은 회귀법과 보간법을 활용하는 것이다.
+
+def f(x): #? 근사할 목표 함수
+  return np.sin(x) + 0.5 * x
+
+def create_plot(x, y, styles, labels, axlabels):
+  plt.figure(figsize=(10, 6))
+  for i in range(len(x)):
+    plt.plot(x[i], y[i], styles[i], label=labels[i])
+    plt.xlabel(axlabels[0])
+    plt.ylabel(axlabels[1])
+  plt.legend(loc=0)
+
+x = np.linspace(-2 * np.pi, 2 * np.pi, 50)
+
+# create_plot([x], [f(x)], ['b'], ['f(x)'], ['x', 'f(x)'])
+
+# TODO: 회귀법
+
+#? 단항식
+res = np.polyfit(x, f(x), deg=7, full=True) #? 최적의 매개변수 결정
+"""
+#! np.polyfit() 매개변수
+#* x : x 좌표 (독립 변수)
+#* y : y 좌표 (종속 변수)
+#* deg : 회귀 다항식의 차수
+#* full : True면 추가적인 진단 정보 반환
+#* w : y 좌표에 적용할 가중치
+#* cov : True면 공분산행렬도 반환
+"""
+ry = np.polyval(res[0], x) #? 근찻값 계산
+
+np.allclose(f(x), ry) #? 온벽히 일치하는지 확인 (False)
+
+# create_plot([x, x], [f(x), ry], ['b', 'r.'], ['f(x)', 'regression'], ['x', 'f(x)'])
+
+#? 개별식
+#! 목표 함수에 대해 어느정도 알고 있을 때 사용하여 학습 효과 극대화
+matrix = np.zeros((4, len(x))) #? 기저 함수 정의
+matrix[3, :] = np.sin(x) #* 목표함수와 비슷한 값을 부여
+matrix[2, :] = x ** 2
+matrix[1, :] = x
+matrix[0, :] = 1
+
+reg = np.linalg.lstsq(matrix.T, f(x), rcond=None)[0] #? 회귀 분석
+ry = np.dot(reg, matrix) #? 함수에 대한 회귀분석 추정값
+
+np.allclose(f(x), ry) #? 온벽히 일치하는지 확인 (True)
+
+# create_plot([x, x], [f(x), ry], ['b', 'r.'], ['f(x)', 'regression'], ['x', 'f(x)'])
+
+# TODO: 보간법
+#! x 차원의 정렬된 관측점이 주어졌을 때, 2개의 이웃하는 관측점 사이의 자료 계산하는 보간 함수를 찾는 과정
+#! 각 관측점은 연속 미분 가능한 함수
+#! 보간 함수는 큐빅 스플라인 함수
+
+ipo = spi.splrep(x, f(x), k=1) #? 선형 스플라인 보간 구현
+""" 
+#! splrep() 매개변수
+#* x : 정렬된 x 좌표(독립 변수)
+#* y : 방향으로 정렬된 y 좌표(종속 변수)
+#* w : y 좌효에 적용할 가중치
+#* xb, xe : 적용 구간 (기본값은 [x[0],x[-1]])
+#* k : 스플라인 함수의 차수 (1~5)
+#* s : 숫자가 커질수록 부드러워짐
+#* full_output : True면 추가적인 출력 반환
+#* quiet : True면 메세지 미출력
+"""
+iy = spi.splev(x, ipo) #?  보간된 값 유도
+""" 
+#! splev() 매개변수
+#* x : 정렬된 x 좌표(독립 변수)
+#* tck : splerp가 반환한 값
+#* der : 미분 차수
+#* ext : x가 범위 밖인 경우의 행동 (0: 외삽, 1: 0으로 지정, 2: ValueError)
+"""
+
+np.allclose(f(x), iy) #? 온벽히 일치하는지 확인 (True)
+
+create_plot([x, x], [f(x), iy], ['b', 'ro'], ['f(x)', 'interpolation'], ['x', 'f(x)'])
+plt.show()
+
+""" 
+#? 보간법이 회귀법보다 더 정확한 근사가 가능
+#? 하지만 데이터가 정렬되어 있어야 하고, 잡음이 없어야 한다.
+#? 그리고 계산량이 많아 리소스가 많이 필요하다.
+"""

--- a/Financial-Analysis/Financial_math/integration.py
+++ b/Financial-Analysis/Financial_math/integration.py
@@ -1,0 +1,27 @@
+import numpy as np
+import sympy as sy
+import scipy.integrate as sci
+
+def f(x):
+  return np.sin(x) + 0.5 * x
+
+a, b = 0.5, 9.5
+
+# TODO: 수치 적분
+
+# sci.fixed_quad(f, a, b)[0] #? 가우스 구적법
+# sci.quad(f, a, b)[0] #? 적응 구적법
+# sci.romberg(f, a, b) #? 롬베르크 적분법
+
+# TODO: 심볼릭 연산
+#? 심볼 정의
+x = sy.Symbol('x')
+y = sy.Symbol('y')
+
+sy.solve(x ** 2 + y ** 2) #? 방성식 연산(해당 방정식의 모든 해 반환)
+
+a, b = sy.symbols('a b') #? 적분 구간 정의
+I = sy.Integral(sy.sin(x) + 0.5 * x, (x, a, b)) #? 적분 객체 정의
+int_func = sy.integrate(sy.sin(x) + 0.5 * x, x) #? 부정적분 유도
+int_func_limits = sy.integrate(sy.sin(x) + 0.5 * x, (x, a, b)) #? 적분 연산
+int_func_limits.subs({a: 0.5, b: 9.5}).evalf() #? 구간의 수치적 적분 연산

--- a/Financial-Analysis/Financial_math/optimization.py
+++ b/Financial-Analysis/Financial_math/optimization.py
@@ -1,0 +1,71 @@
+import math
+import numpy as np
+import scipy.optimize as sco
+import matplotlib.pyplot as plt
+
+#TODO: 최적화
+#! 최적화에서 전역 최소화를 진행한 후에 국소 최적화를 진행한다. (하나의 국소 최소점에 빠져 다른 값을 탐색하지 못하기 때문)
+def fm(p): #? 목표 함수
+  x, y = p
+  return (np.sin(x) + 0.05 * x ** 2 + np.sin(y) + 0.05 * y ** 2)
+
+def fo(p): #? 목표 함수 + 연산 정보 출력
+  x, y = p
+  z = np.sin(x) + 0.05 * x ** 2 + np.sin(y) + 0.05 * y ** 2
+  print('%8.4f | %8.4f | %8.4f' % (x, y, z))
+  return z
+
+# TODO: 전역 최적화
+# opt1 = sco.brute(fo, ((-10, 10.1, 0.1), (-10, 10.1, 0.1)), finish=None) #? 최적화를 통해 구한 최적 인숫값 : [-1.4, -1.4]
+# fm(opt1) #? 최소화 지점 함수값 : -1,7749
+
+# TODO: 국소 최적화
+# opt2 = sco.fmin(fo, opt1, xtol=0.001, ftol=0.001, maxiter=15, maxfun=20)
+# print(opt2)
+# fm(opt2)
+
+# TODO: 주식 투자의 기대 효용함수 최적화
+""" 
+#? 상황 가정
+#* 두 주식(q)은 모두 10의 비용을 요구한다.
+#* 1년후 주식들은 다음 상태에서 해당 가치(r)를 가진다.
+#*    상태 u: (15, 5)
+#*    상태 d: (5, 12)
+#* 투자자의 예산(w)는 100이다.
+"""
+
+def Eu(p): #? 기대 효용을 최대화하기 위한 최적화 함수
+  s, b = p #? 현재 보유 수
+  return -(0.5 * math.sqrt(s * 15 + b * 5) + 0.5 * math.sqrt(s * 5 + b * 12)) #? sqrt를 통해 최소화를 기반으로 최소화
+
+cons = ({'type': 'ineq', 'fun': lambda p: 100 - p[0] * 10 - p[1] * 10}) #? 제한 조건
+"""
+#* 'type': 'ineq' : 제약 조건이 부등식임을 나타냄
+#* 'fun': lambda p: 100 - p[0] * 10 - p[1] * 10 : 구매 비용이 100을 초과하지 않음
+"""
+
+bnds = ((0, 1000), (0, 1000)) #? 경계 조건 인수
+#* 각 인수는 0 ~ 1000의 값을 갖을 수 있음
+
+result = sco.minimize(Eu, [5, 5], method='SLSQP', bounds=bnds, constraints=cons) #? 최적화
+"""
+#? mininize()
+#* fun : 최적화할 대상
+#* x0 : 초기 추정값
+#* method : 최적화 알고리즘 정의 (SLSQP : 경계와 제약 조건 처리)
+#* bounds : 변수의 경계 지정
+#* constraints : 제악 조건 정의
+"""
+
+"""
+#? minimize()의 결과
+#* fun : 최적화된 기대 효용 함수 값 (최소화를 진행 했으므로 해당 값의 절대값)
+#* x : 최적화된 변수 값
+#* nit : 반복 횟수
+#* jac : 목적 함수의 최종 기울기 벡터
+#* nfev : 목적 함수의 평가 횟수
+#* njev : 기울기 평가 횟수
+"""
+
+result['x'] #? [8.025, 1.975] : 1번 주식 8개, 2번 주식 2개가 최적의 값임
+-result['fun'] #? 9.700 : 기대 효용 값이 9.7임


### PR DESCRIPTION
금융 분야에서 사용되는 수학적 이론 및 도구 정리. 해당 이론 및 도구들은 다음과 같은 금융 분야에서 사용된다.

- 함수 근사 : 이자율 곡선 보가, 아메리칸 옵션 가치 계산, 회귀 기반 몬테카를로 분석
- 최적화 : 가격결정 모형, 시장 호가 및 내재 변동성 결정
- 적분 : 파생상품 가격결정, 중립 확률 측정, 최종 가치 판단